### PR TITLE
Implement Qwen model caching and prefetch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ python app.py --root "D:\Datasets" --models_dir ".\models"
 
 # Or specify custom paths
 python app.py --root "C:\Your\Dataset\Path" --models_dir "C:\Your\Models\Path" --port 7860
+# (Optional) Pre-download Qwen reasoning model to the models directory
+python app.py --root "D:\Datasets" --models_dir ".\models" --prefetch-qwen
 ```
 
 ### 3. Using the Interface
@@ -115,6 +117,7 @@ Edit `<project>\meta\project.json` to customize:
 ### Optional Reasoning Enhancement
 - `Qwen/Qwen2.5-VL-7B-Instruct` (detailed analysis)
 - Enable via `reasoning.enabled: true` in project config
+- Model files are cached under `--models_dir`; use `--prefetch-qwen` to download ahead of time
 
 ### Single Model Alternative
 - `openbmb/MiniCPM-V-2_6` (all-in-one option)

--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 from src.ui.app import CaptionStrikeUI
+from src.adapters.qwen_vl_reasoner import download_qwen_model
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -205,6 +206,12 @@ For more information, see README.md
         action="store_true",
         help="Create public Gradio link (use with caution)"
     )
+
+    parser.add_argument(
+        "--prefetch-qwen",
+        action="store_true",
+        help="Download Qwen2.5-VL model files to --models_dir and exit",
+    )
     
     args = parser.parse_args()
     
@@ -220,17 +227,21 @@ For more information, see README.md
         # Validate paths
         root_dir, models_dir = validate_paths(args.root, args.models_dir)
         
+        if args.prefetch_qwen:
+            download_qwen_model("Qwen/Qwen2.5-VL-7B-Instruct", models_dir)
+            return 0
+
         # Print startup info
         print_startup_info(root_dir, models_dir, args.port)
-        
+
         # Initialize UI
         logger.info("Initializing CaptionStrike UI...")
         ui = CaptionStrikeUI(root_dir, models_dir)
-        
+
         # Build interface
         logger.info("Building Gradio interface...")
         interface = ui.build_interface()
-        
+
         # Launch application
         logger.info(f"Launching web interface on {args.host}:{args.port}")
         interface.launch(
@@ -240,7 +251,7 @@ For more information, see README.md
             show_error=True,
             quiet=not args.verbose
         )
-        
+
         return 0
         
     except KeyboardInterrupt:

--- a/src/adapters/person_isolator.py
+++ b/src/adapters/person_isolator.py
@@ -15,6 +15,8 @@ import numpy as np
 from PIL import Image
 import torch
 
+logger = logging.getLogger(__name__)
+
 # InsightFace for face detection
 try:
     from insightface.app import FaceAnalysis
@@ -29,8 +31,6 @@ try:
     SAM_AVAILABLE = True
 except ImportError:
     SAM_AVAILABLE = False
-
-logger = logging.getLogger(__name__)
 
 
 class PersonIsolator:

--- a/src/core/io.py
+++ b/src/core/io.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 import logging
+import copy
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ class ProjectConfig:
             config_file: Path to project.json file
         """
         self.config_file = config_file
-        self._config = self.DEFAULT_CONFIG.copy()
+        self._config = copy.deepcopy(self.DEFAULT_CONFIG)
     
     def load(self) -> Dict[str, Any]:
         """Load configuration from file."""

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -60,7 +60,7 @@ class ProcessingPipeline:
         if self.qwen_reasoner is None:
             model_name = config.get("models.reasoning.model", "Qwen/Qwen2.5-VL-7B-Instruct")
             try:
-                self.qwen_reasoner = QwenVLReasoner(model_name)
+                self.qwen_reasoner = QwenVLReasoner(model_name, cache_dir=self.models_dir)
             except Exception as e:
                 logger.warning(f"Failed to load Qwen reasoner: {e}")
                 return None


### PR DESCRIPTION
## Summary
- Lazily import `qwen_vl_utils` with auto-install fallback
- Cache Qwen model files under the user-specified models directory
- Add CLI flag to prefetch Qwen model before launching UI

## Testing
- `pytest -q` *(fails: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_68a21eb4e538832f86713d07b8446a86